### PR TITLE
fix-table in FF dark mode

### DIFF
--- a/program_backlog/index.html
+++ b/program_backlog/index.html
@@ -14,6 +14,7 @@ td, th {
     text-align: left;
     padding: 8px;
 	width: 20%;
+	color: var(--paragraph-text-color);
 }
 </style>
 


### PR DESCRIPTION
Program States table on Program Backlog page not visible in dark mode on Firefox