### PR TITLE
firefox-darkmode

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -123,6 +123,7 @@ td, th {
     border: 1px solid var(--td-th-color);
     text-align: left;
     padding: 8px;
+    color: var(--paragraph-text-color);
 }
 
 .center {


### PR DESCRIPTION
Table data and headers not visible in dark mode on Firefox